### PR TITLE
Updated OVAL feed documentation

### DIFF
--- a/docs/oval-data/README.md
+++ b/docs/oval-data/README.md
@@ -1,30 +1,9 @@
 # OVAL data
 
-KernelCare provides automated live patching for Linux kernels with centralized management, common automation and various vulnerability management tools integration.
+KernelCare provides automated live patching for Linux kernels with centralized management, common automation and integration with vulnerability scanning tools integration.
 
-You can find more information here:
+You can find more information for KernelCare live patching at: [https://tuxcare.com/live-patching-services/kernelcare-enterprise/](https://tuxcare.com/live-patching-services/kernelcare-enterprise/)
 
-* [https://tuxcare.com/live-patching-services/kernelcare-enterprise/](https://tuxcare.com/live-patching-services/kernelcare-enterprise/)
-* [https://docs.tuxcare.com/live-patching-services/#kernelcare-enterprise](https://docs.tuxcare.com/live-patching-services/#kernelcare-enterprise)
+To allow an accurate vulnerability scanning we provide OVAL feeds for our supported distributions. The OVAL feeds specify the necessary rules for the vulnerability scanning software to identify fixed vulnerabilities in the system.
 
-KernelCare OVAL feeds for supported distributions can be found here: [https://patches.kernelcare.com/oval/](https://patches.kernelcare.com/oval/).
-
-A system managed by KernelCare can be detected by the `kernelcare` package presence:
-
-**For RPM-based distributions**
-
-```
-$ rpm -q kernelcare
-```
-
-**For Debian-based distributions**
-
-```
-$ dpkg -s kernelcare
-```
-
-The `kernelcare` packages are signed with the `6dc3d600cdef74bb` PGP key, the public key can be found here: [https://repo.cloudlinux.com/kernelcare/kernelcare.gpg](https://repo.cloudlinux.com/kernelcare/kernelcare.gpg).
-
-
-
-
+The OVAL feeds can be found at: [https://patches.kernelcare.com/oval/](https://patches.kernelcare.com/oval/).


### PR DESCRIPTION
I've simplified the documentation, written about vulnerability scanners, and remove superfluous text that did not belong to the OVAL section.